### PR TITLE
typescript-should-be-peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   "repository": "https://github.com/deamme/ts-transform-classcat.git",
   "author": "Deam Hansen",
   "license": "MIT",
-  "dependencies": {
-    "typescript": "^2.6.2"
+  "peerDependencies": {
+    "typescript": ">=2.6.2"
   },
   "devDependencies": {
+    "typescript": "^2.6.2",
     "@types/node": "^8.5.2",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.2",


### PR DESCRIPTION
typescript as a peerDependency instead of a direct dependency